### PR TITLE
Update New Relic .NET Core 2.0 agent to fix tests

### DIFF
--- a/images/aspnet-core/runtime-newrelic/Dockerfile
+++ b/images/aspnet-core/runtime-newrelic/Dockerfile
@@ -6,7 +6,7 @@ CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A} \
 CORECLR_NEWRELIC_HOME=/usr/local/newrelic-netcore20-agent \
 CORECLR_PROFILER_PATH=/usr/local/newrelic-netcore20-agent/libNewRelicProfiler.so
 
-RUN curl https://download.newrelic.com/dot_net_agent/latest_release/newrelic-netcore20-agent_8.15.455.0_amd64.deb -o newrelic-netcore-agent.deb
+RUN curl https://download.newrelic.com/dot_net_agent/latest_release/newrelic-netcore20-agent_8.19.353.0_amd64.deb -o newrelic-netcore-agent.deb
 RUN dpkg -i newrelic-netcore-agent.deb
 
 LABEL authors="Armut.com <dev@armut.com>"

--- a/images/dotnet-core/runtime-newrelic/Dockerfile
+++ b/images/dotnet-core/runtime-newrelic/Dockerfile
@@ -6,7 +6,7 @@ CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A} \
 CORECLR_NEWRELIC_HOME=/usr/local/newrelic-netcore20-agent \
 CORECLR_PROFILER_PATH=/usr/local/newrelic-netcore20-agent/libNewRelicProfiler.so
 
-RUN curl https://download.newrelic.com/dot_net_agent/latest_release/newrelic-netcore20-agent_8.15.455.0_amd64.deb -o newrelic-netcore-agent.deb
+RUN curl https://download.newrelic.com/dot_net_agent/latest_release/newrelic-netcore20-agent_8.19.353.0_amd64.deb -o newrelic-netcore-agent.deb
 RUN dpkg -i newrelic-netcore-agent.deb
 
 LABEL authors="Armut.com <dev@armut.com>"


### PR DESCRIPTION
New Relic keeps old releases in different folder, so we have to update to latest version.
https://download.newrelic.com/dot_net_agent/latest_release/newrelic-netcore20-agent_8.15.455.0_amd64.deb moved to https://download.newrelic.com/dot_net_agent/previous_releases/8.15.445.0/newrelic-netcore20-agent_8.15.455.0_amd64.deb but now we use the latest version https://download.newrelic.com/dot_net_agent/latest_release/newrelic-netcore20-agent_8.19.353.0_amd64.deb